### PR TITLE
fix a issue when no watch paired / no watch app installed

### DIFF
--- a/TOTP/CameraView.swift
+++ b/TOTP/CameraView.swift
@@ -98,7 +98,7 @@ class QRScannerController: UIViewController, AVCaptureMetadataOutputObjectsDeleg
                 if let token = Token(url: url! as URL) {
                     messageLabel.backgroundColor = UIColor.gray
                     messageLabel.textColor = UIColor.green
-                    messageLabel.text = "Autorized"
+                    messageLabel.text = "Authorized"
                     print("ScanedInfo:\(token), source: \(metadataObj.stringValue)")
                     dismiss(animated: true, completion: nil)
                     Answers.logContentView(withName: "UseQR", contentType: "CAmera", contentId: "QRScaner", customAttributes: ["Favorites Count":30, "Screen Orientation":"Portrait"])

--- a/TOTP/CloudDataManager.swift
+++ b/TOTP/CloudDataManager.swift
@@ -37,7 +37,7 @@ class CloudDataManager {
         if DocumentsDirectory.iCloudDocumentsURL != nil {
             return true
         } else {
-            Alert.showAlert(title: "Error", message: "Please autorize to iCloud for using data backup")
+            Alert.showAlert(title: "Error", message: "Please authorize to iCloud for using data backup")
             return false
         }
     }

--- a/TOTP/MainViewController.swift
+++ b/TOTP/MainViewController.swift
@@ -81,8 +81,11 @@ extension ViewController:WCSessionDelegate {
     }
     
     func transferRealmFile(){
-        if let path = Realm.Configuration().fileURL {
-            WCSession.default().transferFile(path, metadata: nil)
+        if WCSession.isSupported() {
+            let session = WCSession.default()
+            if session.activationState == .activated, let path = Realm.Configuration().fileURL {
+                session.transferFile(path, metadata: nil)
+            }
         }
     }
 


### PR DESCRIPTION
transferRealmFile is always called even if  WCSession is not activated.
When my iPhone doesn't have an Apple Watch paired, or my Watch doesn't have 2Pass Installed,
the debug output would be occupied by errors like: (every seconds)
```
[WC] WCSession has not been activated
[WC] -[WCSession notifyOfFileError:withFileTransfer:] <WCSessionFileTransfer: 0x2823b82d0, session file: <WCSessionFile: 0x2815d5c00, identifier: 6DE67D38-C2B0-4177-889A-D6D750E568D9, file: /var/mobile/Containers/Data/Application/00A2C473-5115-4AA0-844E-3D5D045ADC71/Documents/default.realm, hasMetadata: NO>, transferring: NO> with WCErrorCodeSessionNotActivated
[WC] -[WCSession onqueue_notifyOfFileError:withFileTransfer:]_block_invoke dropping as pairingIDs no longer match. pairingID (null), client pairingID: (null)
[WC] no pairingID
```
